### PR TITLE
Importpoke Missing Parameter Fix

### DIFF
--- a/models/pokemon.js
+++ b/models/pokemon.js
@@ -862,7 +862,7 @@ Pokemon.prototype.importPokemon = function (connection, P, importString) {
     }.bind(this)
   );
 
-  return this.getPokemonAndSpeciesData(P).then(
+  return this.getPokemonAndSpeciesData(connection, P).then(
     //assign types, base states and then calculate those Stats
     function (response) {
       this.assignTypes();


### PR DESCRIPTION
Restored missing connection parameter in the getPokemonAndSpeciesData call in pokemon.js's importpoke function(line 865 at the time of pushing).